### PR TITLE
5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 5.0.0
+* `@ 147f569` - `PortMidi.Reader` now passes a `buffer_size` to the underlying nif, saving MIDI messages from being lost. This `buffer_size` is set to 256 by default, and can be configured at application level: `config :portmidi, buffer_size: 1024`
+* `@ ed9e3bb` - `PortMidi.Reader` now emits messages as lists, no more as simple tuples. Sometimes there could be only one message, but a list is always returned. The tuples have also changed structure, to include timestamps, that were previously ignored: `[{{status, note1, note2}, timestamp}, ...]`
+* `@ d202f7a` - `PortMidi.Writer` now accepts good old message tuples (`{status, note1, note2}`), event tuples, with timestamp (`{{status, note1, note2}, timestamp}`) or lists of event tuples (`[{{status, note1, note2}, timestamp}, ...]`). This is the preferred way for high throughput, and can be safely used as a pipe from an input device.
+
 ## 4.1.0
 * `@ 614a27e` - Opening inputs and outputs now return `{:error, reason}` if Portmidi can't open the given device. Previously, the Portmidid NIFs would just throw a bad argument error, without context. `reason` is an atom representing an error from the C library. Have a look at `src/portmidi_shared.c#makePmErrorAtom` for all possible errors.
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ def application do
 end
 ```
 
+## Configuration
+
+If needed, the input buffer size can be set, in your `config.exs`:
+
+```
+  config :portmidi, buffer_size: 1024
+```
+
+By default, this value is 256.
+
 ## Usage
 
 To send MIDI events to a MIDI device:
@@ -29,7 +39,16 @@ iex(1)> {:ok, output} = PortMidi.open(:output, "Launchpad Mini")
 iex(2)> PortMidi.write(output, {176, 0, 127})
 :ok
 
-iex(3)> PortMidi.close(:output, output)
+iex(3)> PortMidi.write(output, {{176, 0, 127}, 123}) # with timestamp
+:ok
+
+iex(4)> PortMidi.write(output, [
+iex(5)>   {{176, 0, 127}, 123},
+iex(6)>   {{178, 0, 127}, 128}
+iex(7)> ]) # as a sequence of events (more efficient)
+:ok
+
+iex(8)> PortMidi.close(:output, output)
 :ok
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add portmidi to your list of dependencies in `mix.exs`, and ensure
 that `portmidi` is started before your application:
 ```
 def deps do
-  [{:portmidi, "~> 4.0"}]
+  [{:portmidi, "~> 5.0"}]
 end
 
 def application do

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add portmidi to your list of dependencies in `mix.exs`, and ensure
 that `portmidi` is started before your application:
 ```
 def deps do
-  [{:portmidi, "~> 3.1"}]
+  [{:portmidi, "~> 4.0"}]
 end
 
 def application do

--- a/lib/portmidi.ex
+++ b/lib/portmidi.ex
@@ -63,21 +63,18 @@ defmodule PortMidi do
     Input.listen(input, pid)
 
   @doc """
-    Writes a MIDI event to the given `output` device. `message` must be a tuple
-    `{status, note, velocity}`. Returns `:ok` on write.
+    Writes a MIDI event to the given `output` device. `message` can be a tuple
+    `{status, note, velocity}`, a tuple `{{status, note, velocity}, timestamp}`
+    or a list `[{{status, note, velocity}, timestamp}, ...]`. Returns `:ok` on write.
   """
-  @spec write(pid(), {byte(), byte(), byte()}) :: :ok
+  @type message :: {byte(), byte(), byte()}
+  @type timestamp :: byte()
+
+  @spec write(pid(), message) :: :ok
+  @spec write(pid(), {message, timestamp}) :: :ok
+  @spec write(pid(), [{message, timestamp}, ...]) :: :ok
   def write(output, message), do:
     Output.write(output, message)
-
-  @doc """
-    Writes a MIDI event to the given `output` device, with given `timestamp`.
-    `message` must be a tuple `{status, note, velocity}`. Returns `:ok` on
-    write.
-  """
-  @spec write(pid(), {byte(), byte(), byte()}, non_neg_integer()) :: :ok
-  def write(output, message, timestamp), do:
-    Output.write(output, message, timestamp)
 
   @doc """
     Returns a map with input and output devices, in the form of

--- a/lib/portmidi/input/reader.ex
+++ b/lib/portmidi/input/reader.ex
@@ -2,8 +2,10 @@ defmodule PortMidi.Input.Reader do
   import PortMidi.Nifs.Input
   alias PortMidi.Input.Server
 
+  @buffer_size Application.get_env(:portmidi, :buffer_size, 256)
+
   def start_link(server, device_name) do
-    Agent.start_link fn -> do_start(server, device_name) end
+    Agent.start_link fn -> start(server, device_name) end
   end
 
   # Client implementation
@@ -19,8 +21,7 @@ defmodule PortMidi.Input.Reader do
 
   # Agent implementation
   ######################
-
-  defp do_start(server, device_name) do
+  defp start(server, device_name) do
     case device_name |> String.to_char_list |> do_open do
       {:ok,    stream} -> {server, stream}
       {:error, reason} -> exit(reason)
@@ -28,16 +29,18 @@ defmodule PortMidi.Input.Reader do
   end
 
   defp do_listen({server, stream}) do
-    task = Task.async fn -> do_loop(server, stream) end
+    task = Task.async fn -> loop(server, stream) end
     {:ok, {server, stream, task}}
   end
 
-  defp do_loop(server, stream) do
-    if do_poll(stream) == :read do
-      Server.new_message(server, stream |> do_read)
-    end
+  defp loop(server, stream) do
+    if do_poll(stream) == :read, do: read_and_send(server,stream)
+    loop(server, stream)
+  end
 
-    do_loop(server, stream)
+  defp read_and_send(server, stream) do
+    messages = do_read(stream, @buffer_size)
+    Server.new_messages(server, messages)
   end
 
   defp do_stop({_server, stream, task}) do

--- a/lib/portmidi/input/server.ex
+++ b/lib/portmidi/input/server.ex
@@ -9,8 +9,8 @@ defmodule PortMidi.Input.Server do
   # Client implementation
   #######################
 
-  def new_message(server, message), do:
-    GenServer.cast(server, {:new_message, message})
+  def new_messages(server, messages), do:
+    GenServer.cast(server, {:new_messages, messages})
 
   def stop(server), do:
     GenServer.stop(server)
@@ -30,10 +30,10 @@ defmodule PortMidi.Input.Server do
     end
   end
 
-  def handle_cast({:new_message, message}, reader) do
+  def handle_cast({:new_messages, messages}, reader) do
     self
     |> Listeners.list
-    |> Enum.each(&(send(&1, {self, message})))
+    |> Enum.each(&(send(&1, {self, messages})))
 
     {:noreply, reader}
   end

--- a/lib/portmidi/nifs/input.ex
+++ b/lib/portmidi/nifs/input.ex
@@ -10,7 +10,7 @@ defmodule PortMidi.Nifs.Input do
   def do_poll(_stream), do:
     raise "NIF library not loaded"
 
-  def do_read(_stream), do:
+  def do_read(_stream, _buffer_size), do:
     raise "NIF library not loaded"
 
   def do_open(_device_name), do:

--- a/lib/portmidi/nifs/output.ex
+++ b/lib/portmidi/nifs/output.ex
@@ -11,7 +11,7 @@ defmodule PortMidi.Nifs.Output do
   def do_open(_device_name), do:
     raise "NIF library not loaded"
 
-  def do_write(_stream, _message, _timestamp), do:
+  def do_write(_stream, _message), do:
     raise "NIF library not loaded"
 
   def do_close(_stream), do:

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule PortMidi.Mixfile do
   use Mix.Project
-  @version "4.2.0"
+  @version "5.0.0"
 
   def project do
     [app: :portmidi,

--- a/src/portmidi_in.c
+++ b/src/portmidi_in.c
@@ -75,6 +75,8 @@ static ERL_NIF_TERM do_read(ErlNifEnv* env, int arc, const ERL_NIF_TERM argv[]) 
   status = enif_make_int(env, Pm_MessageStatus(buffer[0].message));
   data1  = enif_make_int(env, Pm_MessageData1(buffer[0].message));
   data2  = enif_make_int(env, Pm_MessageData2(buffer[0].message));
+  int bufferSize = enif_make_int(env, argv[2]);
+  int numEvents = Pm_Read(*stream, buffer, bufferSize);
 
   return enif_make_tuple3(env, status, data1, data2);
 }
@@ -95,7 +97,7 @@ static ERL_NIF_TERM do_close(ErlNifEnv* env, int arc, const ERL_NIF_TERM argv[])
 static ErlNifFunc nif_funcs[] = {
   {"do_open",  1, do_open},
   {"do_poll",  1, do_poll},
-  {"do_read",  1, do_read},
+  {"do_read",  2, do_read},
   {"do_close", 1, do_close}
 };
 

--- a/test/portmidi/input/server_test.exs
+++ b/test/portmidi/input/server_test.exs
@@ -6,15 +6,15 @@ defmodule PortMidiInputServerTest do
   use ExUnit.Case, async: false
   import Mock
 
-  test "new_message/2 broadcasts to processes in Listeners" do
+  test "new_messages/2 broadcasts to processes in Listeners" do
     {:ok, input} = Agent.start(fn -> [] end)
     Listeners.register(input, self)
 
     Agent.get input, fn(_) ->
-      handle_cast({:new_message, {176, 0, 127}}, nil)
+      handle_cast({:new_messages, %{message: {176, 0, 127}, timestamp: 0}}, nil)
     end
 
-    assert_received {input, {176, 0, 127}}
+    assert_received {input, %{message: {176, 0, 127}, timestamp: 0}}
   end
 
   test "terminating the server calls close on the reader" do


### PR DESCRIPTION
* `@ 147f569` - `PortMidi.Reader` now passes a `buffer_size` to the underlying nif, saving MIDI messages from being lost. This `buffer_size` is set to 256 by default, and can be configured at application level: `config :portmidi, buffer_size: 1024`
* `@ ed9e3bb` - `PortMidi.Reader` now emits messages as lists, no more as simple tuples. Sometimes there could be only one message, but a list is always returned. The tuples have also changed structure, to include timestamps, that were previously ignored: `[{{status, note1, note2}, timestamp}, ...]`
* `@ d202f7a` - `PortMidi.Writer` now accepts good old message tuples (`{status, note1, note2}`), event tuples, with timestamp (`{{status, note1, note2}, timestamp}`) or lists of event tuples (`[{{status, note1, note2}, timestamp}, ...]`). This is the preferred way for high throughput, and can be safely used as a pipe from an input device.