### PR TITLE
Fix Hanging On Input Read

### DIFF
--- a/lib/portmidi/input/reader.ex
+++ b/lib/portmidi/input/reader.ex
@@ -4,6 +4,7 @@ defmodule PortMidi.Input.Reader do
   require Logger
 
   @buffer_size Application.get_env(:portmidi, :buffer_size, 256)
+  @input_poll_sleep Application.get_env(:portmidi, :input_poll_sleep, 1)
 
   def start_link(server, device_name) do
     Agent.start_link fn -> start(server, device_name) end
@@ -36,7 +37,7 @@ defmodule PortMidi.Input.Reader do
 
   defp loop(server, stream) do
     if do_poll(stream) == :read, do: read_and_send(server,stream)
-    :timer.sleep(1)
+    :timer.sleep(@input_poll_sleep)
     loop(server, stream)
   end
 

--- a/lib/portmidi/input/reader.ex
+++ b/lib/portmidi/input/reader.ex
@@ -42,7 +42,6 @@ defmodule PortMidi.Input.Reader do
   end
 
   defp read_and_send(server, stream) do
-
     case do_read(stream, @buffer_size) do
       {:error, reason} -> Logger.debug("Error Reading Midi: #{reason}")
       messages -> Server.new_messages(server, messages)

--- a/lib/portmidi/input/reader.ex
+++ b/lib/portmidi/input/reader.ex
@@ -1,6 +1,7 @@
 defmodule PortMidi.Input.Reader do
   import PortMidi.Nifs.Input
   alias PortMidi.Input.Server
+  require Logger
 
   @buffer_size Application.get_env(:portmidi, :buffer_size, 256)
 
@@ -39,8 +40,11 @@ defmodule PortMidi.Input.Reader do
   end
 
   defp read_and_send(server, stream) do
-    messages = do_read(stream, @buffer_size)
-    Server.new_messages(server, messages)
+
+    case do_read(stream, @buffer_size) do
+      {:error, reason} -> Logger.debug("Error Reading Midi: #{reason}")
+      messages -> Server.new_messages(server, messages)
+    end
   end
 
   defp do_stop({_server, stream, task}) do

--- a/lib/portmidi/input/reader.ex
+++ b/lib/portmidi/input/reader.ex
@@ -36,6 +36,7 @@ defmodule PortMidi.Input.Reader do
 
   defp loop(server, stream) do
     if do_poll(stream) == :read, do: read_and_send(server,stream)
+    :timer.sleep(1)
     loop(server, stream)
   end
 

--- a/src/portmidi_in.c
+++ b/src/portmidi_in.c
@@ -61,11 +61,11 @@ static ERL_NIF_TERM do_poll(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
   }
 }
 
-
 static ERL_NIF_TERM do_read(ErlNifEnv* env, int arc, const ERL_NIF_TERM argv[]) {
   PmEvent buffer[MAXBUFLEN];
   int status, data1, data2, timestamp;
   static PortMidiStream ** stream;
+
   ErlNifResourceType* streamType = (ErlNifResourceType*)enif_priv_data(env);
   if(!enif_get_resource(env, argv[0], streamType, (PortMidiStream **) &stream)) {
     return enif_make_badarg(env);
@@ -89,7 +89,6 @@ static ERL_NIF_TERM do_read(ErlNifEnv* env, int arc, const ERL_NIF_TERM argv[]) 
       timestamp
     );
   }
-
   return enif_make_list_from_array(env, events, numEvents);
 }
 
@@ -100,9 +99,7 @@ static ERL_NIF_TERM do_close(ErlNifEnv* env, int arc, const ERL_NIF_TERM argv[])
   if(!enif_get_resource(env, argv[0], streamType, (PortMidiStream **) &stream)) {
     return enif_make_badarg(env);
   }
-
   Pm_Close(*stream);
-
   return enif_make_atom(env, "ok");
 }
 


### PR DESCRIPTION
Just started working with this lib for a project I was on and was having segfaults, buffer overflows, and general hanging when trying to read my keyboard. Turns out there were a couple things wrong:

1. When reading from midi, bufferSize was incorrectly being looked up as the third arg in a two arg list. In addition it was being decoded using the c -> erl encoding (enif_make_\*) instead of the erl -> c (enif_get_\*). The type was also being used incorrectly, should be a long instead of an int I believe.

2. Pm_Read was being used incorrectly. It can return negative values if it errors out, these were not being handled and were just being used as if they were positive integers, resulting in massive allocation requests and segfaults when the array was then created with a near max int number (from the negative number wrapping around as an unsigned int). These errors are now properly caught and passed out to be logged.

3. Even when the above 2 issues were fixed, the lack of a sleep in between polling loop was locking up my device. I saw another PR for this but I didn't like how it did the sleep in C-space as A. the usleep function is not guaranteed to be in every platform, and B. It makes the nif more complicated and instead of just exposing the portmidi API introduced client-side logic to it. I have instead used elixir's :timer.sleep and exposed the amount to sleep as configurable. In my testing even a 1 ms sleep seems adequate.